### PR TITLE
nodejs-v24 ci image

### DIFF
--- a/nodejs/v24-alpine/Dockerfile.multiarch
+++ b/nodejs/v24-alpine/Dockerfile.multiarch
@@ -1,0 +1,28 @@
+FROM node:24-alpine
+
+LABEL maintainer="openCloud Team team@opencloud.eu" \
+  org.opencontainers.image.title="openCloud CI nodejs Image" \
+  org.opencontainers.image.vendor="openCloud GmbH" \
+  org.opencontainers.image.authors="openCloud GmbH" \
+  org.opencontainers.image.description="Custom nodejs image for CI with pnpm" \
+  org.opencontainers.image.documentation="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.url="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.source="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.version="24"
+
+
+# 1. install dependencies
+RUN apk update && apk add --no-cache \
+    git \
+    make \
+    curl \
+    wget \
+    bash 
+
+# 2. install pnpm
+RUN npm install -g pnpm@10.26.1
+
+RUN echo "Node: $(node --version)" && echo "pnpm: $(pnpm --version)"
+
+WORKDIR /app
+CMD ["sh"]

--- a/nodejs/v24/Dockerfile.multiarch
+++ b/nodejs/v24/Dockerfile.multiarch
@@ -1,0 +1,37 @@
+FROM ubuntu:24.04
+
+LABEL maintainer="openCloud Team team@opencloud.eu" \
+  org.opencontainers.image.title="openCloud CI nodejs Image based on Ubuntu 24.04" \
+  org.opencontainers.image.vendor="openCloud GmbH" \
+  org.opencontainers.image.authors="openCloud GmbH" \
+  org.opencontainers.image.description="Custom nodejs image for CI with pnpm" \
+  org.opencontainers.image.documentation="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.url="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.source="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.version="24"
+
+# install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    jq \
+    git \
+    make \
+    ca-certificates \
+    gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm@10.26.1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install playwright dependencies without browsers
+RUN npx -y playwright@1.57.0 install-deps
+
+RUN node --version && pnpm --version
+
+WORKDIR /app
+CMD ["/bin/bash"]


### PR DESCRIPTION
I couldn't create an image based on node:25-alpine 

- `mcr.microsoft.com/playwright:v1.57.0-noble` is too big 3.59 GB. It contains playwright/browsers/browser dependancy/node but doesn't contain `pnpm`. We don't need browsers in the image because we restore browsers from s3 store. 

- own image based on `node:24-alpine` is really light.
<img width="1132" height="201" alt="image" src="https://github.com/user-attachments/assets/8820298c-e645-4bdb-b168-860b873b00c7" />
 we can use it for unit tests but for e2e tests it doesn't fit because Playwright doesn't support  https://playwright.dev/docs/intro#system-requirements and https://playwright.dev/docs/docker#alpine

```
pnpm exec playwright install --with-deps
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu24.04-x64 as a fallback. 
```


- own image based on `ubuntu:24.04` contains node/pnpm/browser deps/all needed deps
<img width="1133" height="206" alt="image" src="https://github.com/user-attachments/assets/70eed2bb-6e1a-462e-8495-dec4c80bf9e1" />



the most optimal to have 2 own images based on `ubuntu-24` for e2e test and `node:24-alpine` for unit tests and others actions


Browser dependencies are also installed in the image. We store browsers in our S3 storage and install them separately (restore from cache → unpack).
When we update Playwright and browsers, they remain compatible with existing dependencies in the image.


e2e tests are green https://ci.opencloud.rocks/repos/6/pipeline/732