### PR TITLE
php:8.4 for acceptance tests

### DIFF
--- a/php/v8.4/Dockerfile.multiarch
+++ b/php/v8.4/Dockerfile.multiarch
@@ -1,0 +1,47 @@
+FROM php:8.4.15-alpine3.22
+
+LABEL maintainer="openCloud Team team@opencloud.eu" \
+  org.opencontainers.image.title="openCloud CI PHP Image" \
+  org.opencontainers.image.vendor="openCloud GmbH" \
+  org.opencontainers.image.authors="openCloud GmbH" \
+  org.opencontainers.image.description="Custom PHP image for CI with Behat support" \
+  org.opencontainers.image.documentation="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.url="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.source="https://github.com/opencloud-eu/container-ci" \
+  org.opencontainers.image.version="8.4"
+
+RUN apk add --no-cache \
+    git \
+    zip \
+    unzip \
+    curl \
+    bash \
+    make \
+    rsync \
+    ncurses
+
+RUN apk add --no-cache \
+    libzip \
+    openldap \
+    && apk add --no-cache --virtual .build-deps \
+    $PHPIZE_DEPS \
+    libzip-dev \
+    openldap-dev \
+    && docker-php-ext-install -j$(nproc) \
+        zip \
+        opcache \
+        ldap \
+    && apk del .build-deps
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+RUN echo "error_reporting = E_ALL & ~E_DEPRECATED" \
+    > /usr/local/etc/php/conf.d/99-error-reporting.ini
+
+RUN git --version && \
+    composer --version && \
+    make --version
+
+WORKDIR /app
+
+CMD ["php", "-v"]


### PR DESCRIPTION
Created image based on `php:8.4.15-alpine3.22` for acceptance tests

### test localy using image: 
- build: `docker build --no-cache -f php/8.4/Dockerfile.multiarch -t php:8.4 .`
- run tests using `php:8.4` image (replace here tests/acceptance/docker/src/acceptance.yml:3)
```
opencloud % WITH_WRAPPER=false BUILD_DEV_IMAGE=0 OC_IMAGE_TAG=dev \
BEHAT_FEATURE='tests/acceptance/features/apiGraphUserGroup/createUser.feature:26' \
make -C tests/acceptance/docker test-opencloud-feature-decomposed-storage
```
Result: 

test runs

```
    Then the HTTP status code should be "<http-status-code>"                                    # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "<user>" <should-or-not> exist                                                     # FeatureContext::userShouldNotExist()
    Examples:
      | user                         | display-name | email           | password | http-status-code | enable | should-or-not |
      | nameWithCharacters(*:!;_+-&) | user         | new@example.org | 123      | 400              | true   | should not    |

1 scenario (1 passed)
5 steps (5 passed)
0m0.86s (19.02Mb)
runsh: Total 1 scenarios (1 passed, 0 failed)
```



tests in the CI: https://ci.opencloud.rocks/repos/3/pipeline/739