### PR TITLE
fix: Add vips-magick and imagemagick

### DIFF
--- a/golang/v1.25/Dockerfile.multiarch
+++ b/golang/v1.25/Dockerfile.multiarch
@@ -20,9 +20,11 @@ RUN apk update && \
         ca-certificates \
         build-base \
         attr \
+        imagemagick \
         inotify-tools \
         vips \
         vips-dev \
+        vips-magick \
         vips-tools \
         glib \
         expat \


### PR DESCRIPTION
With the update to govips-2.17.0 the processing of BMP files was switch to use imagemagick.