### PR TITLE
fix: add missing python3-tk system lib

### DIFF
--- a/.woodpecker/desktop-client-build.yml
+++ b/.woodpecker/desktop-client-build.yml
@@ -9,11 +9,12 @@ variables:
           from_secret: docker_username
         password:
           from_secret: docker_password
-      - registry: https://quay.io
-        username:
-          from_secret: quay_username
-        password:
-          from_secret: quay_password
+      # TODO: Enable quay registry once the repo is available
+      # - registry: https://quay.io
+      #   username:
+      #     from_secret: quay_username
+      #   password:
+      #     from_secret: quay_password
       - registry: https://registry.heinlein.group
         username:
           from_secret: harbor_opencloud_user

--- a/desktop-client-build/Dockerfile.multiarch
+++ b/desktop-client-build/Dockerfile.multiarch
@@ -96,6 +96,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb-xkb1 \
     libxkbcommon-x11-0 \
     ### For GUI test
+    python3-tk \
     python3-venv \
     python3-nautilus \
     xclip \


### PR DESCRIPTION
Install missing `python3-tk`, required for pyautogui to work in the GUI tests.