### PR TITLE
ci: disable push to quay registry for now

### DIFF
--- a/.woodpecker/desktop-client-build.yml
+++ b/.woodpecker/desktop-client-build.yml
@@ -1,7 +1,9 @@
 ---
 variables:
   - &buildx_plugin 'docker.io/woodpeckerci/plugin-docker-buildx:latest'
-  - &publish_repos 'opencloudeu/desktop-client-build,quay.io/opencloudeu/desktop-client-build'
+  # TODO: Enable quay registry once the repo is available
+  # - &publish_repos 'opencloudeu/desktop-client-build,quay.io/opencloudeu/desktop-client-build'
+  - &publish_repos 'opencloudeu/desktop-client-build'
   - &publish_platforms 'linux/amd64'
   - publish_logins: &publish_logins
       - registry: https://index.docker.io/v1/
@@ -9,12 +11,11 @@ variables:
           from_secret: docker_username
         password:
           from_secret: docker_password
-      # TODO: Enable quay registry once the repo is available
-      # - registry: https://quay.io
-      #   username:
-      #     from_secret: quay_username
-      #   password:
-      #     from_secret: quay_password
+      - registry: https://quay.io
+        username:
+          from_secret: quay_username
+        password:
+          from_secret: quay_password
       - registry: https://registry.heinlein.group
         username:
           from_secret: harbor_opencloud_user


### PR DESCRIPTION
we need to have empty repo in quay registry to be able to push the image. But the person who can do it is not available at the moment, so I disabled the push to quay registry. Image tags will be pushed only to docker registry for now


CC @flimmy Could you create an empty repo `desktop-client-build` in quay registry?