### PR TITLE
build(desktop-client-build): inlcude openvfs binary

### DIFF
--- a/desktop-client-build/Dockerfile.multiarch
+++ b/desktop-client-build/Dockerfile.multiarch
@@ -101,6 +101,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-nautilus \
     xclip \
     gnome-keyring \
+    # capture screenshot
+    gnome-screenshot \
     # browser dependencies
     libnspr4 \
     libnss3 \

--- a/desktop-client-build/scripts/clean-openbuild.sh
+++ b/desktop-client-build/scripts/clean-openbuild.sh
@@ -60,4 +60,5 @@ find ./bin \( -type f -o -type l \) \
     ! -name "qmltime" \
     ! -name "qtpaths" \
     ! -name "svgtoqml" \
+    ! -name "openvfs" \
     -delete


### PR DESCRIPTION
inlcude openvfs binary required to build the client with vfs on and add `gnome-screenshot` system lib required for the tests