### PR TITLE
build(desktop-client-build): use main branch to get the client build dependencies

### DIFF
--- a/.woodpecker/desktop-client-build.yml
+++ b/.woodpecker/desktop-client-build.yml
@@ -49,9 +49,6 @@ steps:
       pull_image: true
       repo: *publish_repos
       tags: *image_tags
-      build_args:
-        # remove the following once PR https://github.com/opencloud-eu/desktop/pull/863 is merged
-        ARG_CLIENT_BRANCH: 'build/build-qtbase-with-a11y'
     when:
       - event: pull_request
 

--- a/desktop-client-build/Dockerfile.multiarch
+++ b/desktop-client-build/Dockerfile.multiarch
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=ubuntu
 ARG BASE_TAG=24.04
 
+FROM ${BASE_IMAGE}:26.04 AS stage_libs
+
 FROM ${BASE_IMAGE}:${BASE_TAG} AS stage_build
 
 ARG ARG_CLIENT_BRANCH
@@ -39,6 +41,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvulkan-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=stage_libs /usr/lib/x86_64-linux-gnu/libmount.so* /usr/local/lib/
+COPY --from=stage_libs /usr/lib/x86_64-linux-gnu/libblkid.so* /usr/local/lib/
+
+RUN ldconfig
 
 ######################################################################
 # Install dependencies using craft                                   #
@@ -99,7 +106,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-tk \
     python3-venv \
     python3-nautilus \
-    xclip \
     gnome-keyring \
     # capture screenshot
     gnome-screenshot \
@@ -133,8 +139,15 @@ ENV CLIENT_BRANCH=${ARG_CLIENT_BRANCH:-main} \
 ENV OPENBUILD_BIN_PATH=/openbuild/${CLIENT_BRANCH}/${CLIENT_BUILD_TARGET}
 
 COPY --from=stage_build ${OPENBUILD_BIN_PATH} ${OPENBUILD_BIN_PATH}
+COPY --from=stage_libs /usr/lib/x86_64-linux-gnu/libmount.so* /usr/local/lib/
+COPY --from=stage_libs /usr/lib/x86_64-linux-gnu/libblkid.so* /usr/local/lib/
 
 ENV CMAKE_PREFIX_PATH=${OPENBUILD_BIN_PATH}
+
+# install uv - python package manager
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv $HOME/.local/bin/uv* /usr/local/bin/ \
+    && ldconfig
 
 ENV HOME="/home/ubuntu" \
     STARTUPDIR="/dockerstartup" \

--- a/desktop-client-build/scripts/clean-openbuild.sh
+++ b/desktop-client-build/scripts/clean-openbuild.sh
@@ -61,4 +61,10 @@ find ./bin \( -type f -o -type l \) \
     ! -name "qtpaths" \
     ! -name "svgtoqml" \
     ! -name "openvfs" \
+    ! -name "wasmdeployqt" \
+    ! -name "qmlcontextpropertydump" \
+    ! -name "lcheck" \
+    ! -name "lrelease-pro" \
+    ! -name "lupdate-pro" \
+    ! -name "ltext2id" \
     -delete

--- a/desktop-client-build/xfce/startup/entrypoint.sh
+++ b/desktop-client-build/xfce/startup/entrypoint.sh
@@ -76,4 +76,4 @@ fi
 echo ""
 echo "#############################[ GUI Tests ]#############################"
 echo "[INFO] Run GUI tests: behave ${BEHAVE_PARAMETERS}"
-behave ${BEHAVE_PARAMETERS}
+uv run behave ${BEHAVE_PARAMETERS}


### PR DESCRIPTION
Use `main` branch to get the client build dependencies and add/remove libraries